### PR TITLE
First draft grammar update

### DIFF
--- a/packages/babel-parser/src/tokenizer/state.js
+++ b/packages/babel-parser/src/tokenizer/state.js
@@ -78,6 +78,8 @@ export default class State {
   soloAwait: boolean = false;
   inFSharpPipelineDirectBody: boolean = false;
 
+  soloRecall: boolean = false;
+
   // Check whether we are in a (nested) class or not.
   classLevel: number = 0;
 

--- a/packages/babel-parser/src/tokenizer/types.js
+++ b/packages/babel-parser/src/tokenizer/types.js
@@ -196,5 +196,4 @@ export const types: { [name: string]: TokenType } = {
   _delete: createKeyword("delete", { beforeExpr, prefix, startsExpr }),
   perform: createKeyword("perform", { prefix, startsExpr, beforeExpr }),
   handle: createKeyword("handle", { prefix, startsExpr, beforeExpr }),
-  recall: createKeyword("recall", { prefix, startsExpr, beforeExpr }),
 };

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1463,5 +1463,6 @@ export type Placeholder<N: PlaceholderTypes> = NodeBase & {
 export type ParseSubscriptState = {
   optionalChainMember: boolean,
   maybeAsyncArrow: boolean,
+  maybeEffectArrow: boolean,
   stop: boolean,
 };

--- a/packages/babel-parser/src/util/scope.js
+++ b/packages/babel-parser/src/util/scope.js
@@ -16,6 +16,7 @@ import {
   BIND_KIND_VALUE,
   type ScopeFlags,
   type BindingTypes,
+  SCOPE_EFFECT,
 } from "./scopeflags";
 import * as N from "../types";
 
@@ -57,6 +58,9 @@ export default class ScopeHandler<IScope: Scope = Scope> {
   }
   get inAsync() {
     return (this.currentVarScope().flags & SCOPE_ASYNC) > 0;
+  }
+  get inEffect() {
+    return (this.currentVarScope().flags & SCOPE_EFFECT) > 0;
   }
   get allowSuper() {
     return (this.currentThisScope().flags & SCOPE_SUPER) > 0;

--- a/packages/babel-parser/src/util/scopeflags.js
+++ b/packages/babel-parser/src/util/scopeflags.js
@@ -2,17 +2,18 @@
 
 // Each scope gets a bitset that may contain these flags
 // prettier-ignore
-export const SCOPE_OTHER        = 0b0000000000,
-             SCOPE_PROGRAM      = 0b0000000001,
-             SCOPE_FUNCTION     = 0b0000000010,
-             SCOPE_ASYNC        = 0b0000000100,
-             SCOPE_GENERATOR    = 0b0000001000,
-             SCOPE_ARROW        = 0b0000010000,
-             SCOPE_SIMPLE_CATCH = 0b0000100000,
-             SCOPE_SUPER        = 0b0001000000,
-             SCOPE_DIRECT_SUPER = 0b0010000000,
-             SCOPE_CLASS        = 0b0100000000,
-             SCOPE_TS_MODULE    = 0b1000000000,
+export const SCOPE_OTHER        = 0b00000000000,
+             SCOPE_PROGRAM      = 0b00000000001,
+             SCOPE_FUNCTION     = 0b00000000010,
+             SCOPE_ASYNC        = 0b00000000100,
+             SCOPE_GENERATOR    = 0b00000001000,
+             SCOPE_ARROW        = 0b00000010000,
+             SCOPE_SIMPLE_CATCH = 0b00000100000,
+             SCOPE_SUPER        = 0b00001000000,
+             SCOPE_DIRECT_SUPER = 0b00010000000,
+             SCOPE_CLASS        = 0b00100000000,
+             SCOPE_TS_MODULE    = 0b01000000000,
+             SCOPE_EFFECT    = 0b10000000000,
              SCOPE_VAR = SCOPE_PROGRAM | SCOPE_FUNCTION | SCOPE_TS_MODULE;
 
 export type ScopeFlags =
@@ -26,13 +27,19 @@ export type ScopeFlags =
   | typeof SCOPE_SIMPLE_CATCH
   | typeof SCOPE_SUPER
   | typeof SCOPE_DIRECT_SUPER
-  | typeof SCOPE_CLASS;
+  | typeof SCOPE_CLASS
+  | typeof SCOPE_EFFECT;
 
-export function functionFlags(isAsync: boolean, isGenerator: boolean) {
+export function functionFlags(
+  isAsync: boolean,
+  isGenerator: boolean,
+  isEffect: boolean,
+) {
   return (
     SCOPE_FUNCTION |
     (isAsync ? SCOPE_ASYNC : 0) |
-    (isGenerator ? SCOPE_GENERATOR : 0)
+    (isGenerator ? SCOPE_GENERATOR : 0) |
+    (isEffect ? SCOPE_EFFECT : 0)
   );
 }
 

--- a/packages/babel-parser/test/__snapshots__/perform-keyword.js.snap
+++ b/packages/babel-parser/test/__snapshots__/perform-keyword.js.snap
@@ -1,5 +1,1113 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`effect / recall keyword Should parse a function statement as an effect 1`] = `
+Node {
+  "comments": Array [],
+  "end": 127,
+  "errors": Array [],
+  "loc": SourceLocation {
+    "end": Position {
+      "column": 4,
+      "line": 9,
+    },
+    "start": Position {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "program": Node {
+    "body": Array [
+      Node {
+        "end": 57,
+        "expression": Node {
+          "async": false,
+          "body": Node {
+            "body": Array [
+              Node {
+                "end": 49,
+                "expression": Node {
+                  "argument": Node {
+                    "end": 48,
+                    "extra": Object {
+                      "raw": "\\"Hi\\"",
+                      "rawValue": "Hi",
+                    },
+                    "loc": SourceLocation {
+                      "end": Position {
+                        "column": 19,
+                        "line": 3,
+                      },
+                      "start": Position {
+                        "column": 15,
+                        "line": 3,
+                      },
+                    },
+                    "start": 44,
+                    "type": "StringLiteral",
+                    "value": "Hi",
+                  },
+                  "end": 48,
+                  "loc": SourceLocation {
+                    "end": Position {
+                      "column": 19,
+                      "line": 3,
+                    },
+                    "start": Position {
+                      "column": 8,
+                      "line": 3,
+                    },
+                  },
+                  "start": 37,
+                  "type": "RecallExpression",
+                },
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 20,
+                    "line": 3,
+                  },
+                  "start": Position {
+                    "column": 8,
+                    "line": 3,
+                  },
+                },
+                "start": 37,
+                "type": "ExpressionStatement",
+              },
+            ],
+            "directives": Array [],
+            "end": 57,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 7,
+                "line": 4,
+              },
+              "start": Position {
+                "column": 26,
+                "line": 2,
+              },
+            },
+            "start": 27,
+            "type": "BlockStatement",
+          },
+          "effect": true,
+          "end": 57,
+          "generator": false,
+          "id": Node {
+            "end": 24,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 23,
+                "line": 2,
+              },
+              "identifierName": "A",
+              "start": Position {
+                "column": 22,
+                "line": 2,
+              },
+            },
+            "name": "A",
+            "start": 23,
+            "type": "Identifier",
+          },
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 7,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 6,
+              "line": 2,
+            },
+          },
+          "params": Array [],
+          "start": 7,
+          "type": "FunctionExpression",
+        },
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 7,
+            "line": 4,
+          },
+          "start": Position {
+            "column": 6,
+            "line": 2,
+          },
+        },
+        "start": 7,
+        "type": "ExpressionStatement",
+      },
+      Node {
+        "declarations": Array [
+          Node {
+            "end": 122,
+            "id": Node {
+              "end": 72,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 13,
+                  "line": 6,
+                },
+                "identifierName": "B",
+                "start": Position {
+                  "column": 12,
+                  "line": 6,
+                },
+              },
+              "name": "B",
+              "start": 71,
+              "type": "Identifier",
+            },
+            "init": Node {
+              "async": false,
+              "body": Node {
+                "body": Array [
+                  Node {
+                    "end": 114,
+                    "expression": Node {
+                      "argument": Node {
+                        "end": 113,
+                        "extra": Object {
+                          "raw": "\\"Yo\\"",
+                          "rawValue": "Yo",
+                        },
+                        "loc": SourceLocation {
+                          "end": Position {
+                            "column": 19,
+                            "line": 7,
+                          },
+                          "start": Position {
+                            "column": 15,
+                            "line": 7,
+                          },
+                        },
+                        "start": 109,
+                        "type": "StringLiteral",
+                        "value": "Yo",
+                      },
+                      "end": 113,
+                      "loc": SourceLocation {
+                        "end": Position {
+                          "column": 19,
+                          "line": 7,
+                        },
+                        "start": Position {
+                          "column": 8,
+                          "line": 7,
+                        },
+                      },
+                      "start": 102,
+                      "type": "RecallExpression",
+                    },
+                    "loc": SourceLocation {
+                      "end": Position {
+                        "column": 20,
+                        "line": 7,
+                      },
+                      "start": Position {
+                        "column": 8,
+                        "line": 7,
+                      },
+                    },
+                    "start": 102,
+                    "type": "ExpressionStatement",
+                  },
+                ],
+                "directives": Array [],
+                "end": 122,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 7,
+                    "line": 8,
+                  },
+                  "start": Position {
+                    "column": 33,
+                    "line": 6,
+                  },
+                },
+                "start": 92,
+                "type": "BlockStatement",
+              },
+              "effect": true,
+              "end": 122,
+              "generator": false,
+              "id": null,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 7,
+                  "line": 8,
+                },
+                "start": Position {
+                  "column": 16,
+                  "line": 6,
+                },
+              },
+              "params": Array [],
+              "start": 75,
+              "type": "FunctionExpression",
+            },
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 7,
+                "line": 8,
+              },
+              "start": Position {
+                "column": 12,
+                "line": 6,
+              },
+            },
+            "start": 71,
+            "type": "VariableDeclarator",
+          },
+        ],
+        "end": 122,
+        "kind": "const",
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 7,
+            "line": 8,
+          },
+          "start": Position {
+            "column": 6,
+            "line": 6,
+          },
+        },
+        "start": 65,
+        "type": "VariableDeclaration",
+      },
+    ],
+    "directives": Array [],
+    "end": 127,
+    "interpreter": null,
+    "loc": SourceLocation {
+      "end": Position {
+        "column": 4,
+        "line": 9,
+      },
+      "start": Position {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "sourceType": "module",
+    "start": 0,
+    "type": "Program",
+  },
+  "start": 0,
+  "type": "File",
+}
+`;
+
+exports[`effect / recall keyword Should parse a handle keyword 1`] = `
+Node {
+  "comments": Array [],
+  "end": 49,
+  "errors": Array [],
+  "loc": SourceLocation {
+    "end": Position {
+      "column": 3,
+      "line": 5,
+    },
+    "start": Position {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "program": Node {
+    "body": Array [
+      Node {
+        "declarations": Array [
+          Node {
+            "end": 45,
+            "id": Node {
+              "end": 16,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 15,
+                  "line": 2,
+                },
+                "identifierName": "y",
+                "start": Position {
+                  "column": 14,
+                  "line": 2,
+                },
+              },
+              "name": "y",
+              "start": 15,
+              "type": "Identifier",
+            },
+            "init": Node {
+              "async": false,
+              "body": Node {
+                "body": Array [],
+                "directives": Array [],
+                "end": 45,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 9,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 32,
+                    "line": 2,
+                  },
+                },
+                "start": 33,
+                "type": "BlockStatement",
+              },
+              "effect": true,
+              "end": 45,
+              "generator": false,
+              "id": null,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 9,
+                  "line": 4,
+                },
+                "start": Position {
+                  "column": 18,
+                  "line": 2,
+                },
+              },
+              "params": Array [
+                Node {
+                  "end": 28,
+                  "loc": SourceLocation {
+                    "end": Position {
+                      "column": 27,
+                      "line": 2,
+                    },
+                    "identifierName": "x",
+                    "start": Position {
+                      "column": 26,
+                      "line": 2,
+                    },
+                  },
+                  "name": "x",
+                  "start": 27,
+                  "type": "Identifier",
+                },
+              ],
+              "start": 19,
+              "type": "ArrowFunctionExpression",
+            },
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 9,
+                "line": 4,
+              },
+              "start": Position {
+                "column": 14,
+                "line": 2,
+              },
+            },
+            "start": 15,
+            "type": "VariableDeclarator",
+          },
+        ],
+        "end": 45,
+        "kind": "const",
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 9,
+            "line": 4,
+          },
+          "start": Position {
+            "column": 8,
+            "line": 2,
+          },
+        },
+        "start": 9,
+        "type": "VariableDeclaration",
+      },
+    ],
+    "directives": Array [],
+    "end": 49,
+    "interpreter": null,
+    "loc": SourceLocation {
+      "end": Position {
+        "column": 3,
+        "line": 5,
+      },
+      "start": Position {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "sourceType": "module",
+    "start": 0,
+    "type": "Program",
+  },
+  "start": 0,
+  "type": "File",
+}
+`;
+
+exports[`effect / recall keyword Should parse a recall keyword within the scope of an effect 1`] = `
+Node {
+  "comments": Array [],
+  "end": 67,
+  "errors": Array [],
+  "loc": SourceLocation {
+    "end": Position {
+      "column": 4,
+      "line": 5,
+    },
+    "start": Position {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "program": Node {
+    "body": Array [
+      Node {
+        "declarations": Array [
+          Node {
+            "end": 62,
+            "id": Node {
+              "end": 14,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 13,
+                  "line": 2,
+                },
+                "identifierName": "z",
+                "start": Position {
+                  "column": 12,
+                  "line": 2,
+                },
+              },
+              "name": "z",
+              "start": 13,
+              "type": "Identifier",
+            },
+            "init": Node {
+              "async": false,
+              "body": Node {
+                "body": Array [
+                  Node {
+                    "end": 54,
+                    "expression": Node {
+                      "argument": Node {
+                        "end": 54,
+                        "extra": Object {
+                          "raw": "\\"Hello\\"",
+                          "rawValue": "Hello",
+                        },
+                        "loc": SourceLocation {
+                          "end": Position {
+                            "column": 22,
+                            "line": 3,
+                          },
+                          "start": Position {
+                            "column": 15,
+                            "line": 3,
+                          },
+                        },
+                        "start": 47,
+                        "type": "StringLiteral",
+                        "value": "Hello",
+                      },
+                      "end": 54,
+                      "loc": SourceLocation {
+                        "end": Position {
+                          "column": 22,
+                          "line": 3,
+                        },
+                        "start": Position {
+                          "column": 8,
+                          "line": 3,
+                        },
+                      },
+                      "start": 40,
+                      "type": "RecallExpression",
+                    },
+                    "loc": SourceLocation {
+                      "end": Position {
+                        "column": 22,
+                        "line": 3,
+                      },
+                      "start": Position {
+                        "column": 8,
+                        "line": 3,
+                      },
+                    },
+                    "start": 40,
+                    "type": "ExpressionStatement",
+                  },
+                ],
+                "directives": Array [],
+                "end": 62,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 7,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 29,
+                    "line": 2,
+                  },
+                },
+                "start": 30,
+                "type": "BlockStatement",
+              },
+              "effect": true,
+              "end": 62,
+              "generator": false,
+              "id": null,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 7,
+                  "line": 4,
+                },
+                "start": Position {
+                  "column": 16,
+                  "line": 2,
+                },
+              },
+              "params": Array [],
+              "start": 17,
+              "type": "ArrowFunctionExpression",
+            },
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 7,
+                "line": 4,
+              },
+              "start": Position {
+                "column": 12,
+                "line": 2,
+              },
+            },
+            "start": 13,
+            "type": "VariableDeclarator",
+          },
+        ],
+        "end": 62,
+        "kind": "const",
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 7,
+            "line": 4,
+          },
+          "start": Position {
+            "column": 6,
+            "line": 2,
+          },
+        },
+        "start": 7,
+        "type": "VariableDeclaration",
+      },
+    ],
+    "directives": Array [],
+    "end": 67,
+    "interpreter": null,
+    "loc": SourceLocation {
+      "end": Position {
+        "column": 4,
+        "line": 5,
+      },
+      "start": Position {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "sourceType": "module",
+    "start": 0,
+    "type": "Program",
+  },
+  "start": 0,
+  "type": "File",
+}
+`;
+
+exports[`handle keyword Should parse a handle block 1`] = `
+Node {
+  "comments": Array [],
+  "end": 53,
+  "errors": Array [],
+  "loc": SourceLocation {
+    "end": Position {
+      "column": 4,
+      "line": 5,
+    },
+    "start": Position {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "program": Node {
+    "body": Array [
+      Node {
+        "body": Node {
+          "body": Array [
+            Node {
+              "declarations": Array [
+                Node {
+                  "end": 39,
+                  "id": Node {
+                    "end": 35,
+                    "loc": SourceLocation {
+                      "end": Position {
+                        "column": 15,
+                        "line": 3,
+                      },
+                      "identifierName": "x",
+                      "start": Position {
+                        "column": 14,
+                        "line": 3,
+                      },
+                    },
+                    "name": "x",
+                    "start": 34,
+                    "type": "Identifier",
+                  },
+                  "init": Node {
+                    "end": 39,
+                    "extra": Object {
+                      "raw": "0",
+                      "rawValue": 0,
+                    },
+                    "loc": SourceLocation {
+                      "end": Position {
+                        "column": 19,
+                        "line": 3,
+                      },
+                      "start": Position {
+                        "column": 18,
+                        "line": 3,
+                      },
+                    },
+                    "start": 38,
+                    "type": "NumericLiteral",
+                    "value": 0,
+                  },
+                  "loc": SourceLocation {
+                    "end": Position {
+                      "column": 19,
+                      "line": 3,
+                    },
+                    "start": Position {
+                      "column": 14,
+                      "line": 3,
+                    },
+                  },
+                  "start": 34,
+                  "type": "VariableDeclarator",
+                },
+              ],
+              "end": 40,
+              "kind": "const",
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 20,
+                  "line": 3,
+                },
+                "start": Position {
+                  "column": 8,
+                  "line": 3,
+                },
+              },
+              "start": 28,
+              "type": "VariableDeclaration",
+            },
+          ],
+          "directives": Array [],
+          "end": 48,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 7,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 17,
+              "line": 2,
+            },
+          },
+          "start": 18,
+          "type": "BlockStatement",
+        },
+        "effects": Array [
+          Node {
+            "end": 16,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 15,
+                "line": 2,
+              },
+              "identifierName": "A",
+              "start": Position {
+                "column": 14,
+                "line": 2,
+              },
+            },
+            "name": "A",
+            "start": 15,
+            "type": "Identifier",
+          },
+        ],
+        "end": 48,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 7,
+            "line": 4,
+          },
+          "start": Position {
+            "column": 6,
+            "line": 2,
+          },
+        },
+        "start": 7,
+        "type": "EffectHandler",
+      },
+    ],
+    "directives": Array [],
+    "end": 53,
+    "interpreter": null,
+    "loc": SourceLocation {
+      "end": Position {
+        "column": 4,
+        "line": 5,
+      },
+      "start": Position {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "sourceType": "module",
+    "start": 0,
+    "type": "Program",
+  },
+  "start": 0,
+  "type": "File",
+}
+`;
+
+exports[`handle keyword Should parse a handle block as expression 1`] = `
+Node {
+  "comments": Array [],
+  "end": 69,
+  "errors": Array [],
+  "loc": SourceLocation {
+    "end": Position {
+      "column": 4,
+      "line": 5,
+    },
+    "start": Position {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "program": Node {
+    "body": Array [
+      Node {
+        "declarations": Array [
+          Node {
+            "end": 63,
+            "id": Node {
+              "end": 16,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 15,
+                  "line": 2,
+                },
+                "identifierName": "f",
+                "start": Position {
+                  "column": 14,
+                  "line": 2,
+                },
+              },
+              "name": "f",
+              "start": 15,
+              "type": "Identifier",
+            },
+            "init": Node {
+              "body": Node {
+                "body": Array [
+                  Node {
+                    "argument": Node {
+                      "end": 52,
+                      "loc": SourceLocation {
+                        "end": Position {
+                          "column": 21,
+                          "line": 3,
+                        },
+                        "start": Position {
+                          "column": 17,
+                          "line": 3,
+                        },
+                      },
+                      "start": 48,
+                      "type": "NullLiteral",
+                    },
+                    "end": 53,
+                    "loc": SourceLocation {
+                      "end": Position {
+                        "column": 22,
+                        "line": 3,
+                      },
+                      "start": Position {
+                        "column": 10,
+                        "line": 3,
+                      },
+                    },
+                    "start": 41,
+                    "type": "ReturnStatement",
+                  },
+                ],
+                "directives": Array [],
+                "end": 63,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 9,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 28,
+                    "line": 2,
+                  },
+                },
+                "start": 29,
+                "type": "BlockStatement",
+              },
+              "effects": Array [],
+              "end": 63,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 9,
+                  "line": 4,
+                },
+                "start": Position {
+                  "column": 18,
+                  "line": 2,
+                },
+              },
+              "start": 19,
+              "type": "EffectHandler",
+            },
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 9,
+                "line": 4,
+              },
+              "start": Position {
+                "column": 14,
+                "line": 2,
+              },
+            },
+            "start": 15,
+            "type": "VariableDeclarator",
+          },
+        ],
+        "end": 64,
+        "kind": "const",
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 10,
+            "line": 4,
+          },
+          "start": Position {
+            "column": 8,
+            "line": 2,
+          },
+        },
+        "start": 9,
+        "type": "VariableDeclaration",
+      },
+    ],
+    "directives": Array [],
+    "end": 69,
+    "interpreter": null,
+    "loc": SourceLocation {
+      "end": Position {
+        "column": 4,
+        "line": 5,
+      },
+      "start": Position {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "sourceType": "module",
+    "start": 0,
+    "type": "Program",
+  },
+  "start": 0,
+  "type": "File",
+}
+`;
+
+exports[`handle keyword Should parse a nested handle block 1`] = `
+Node {
+  "comments": Array [],
+  "end": 88,
+  "errors": Array [],
+  "loc": SourceLocation {
+    "end": Position {
+      "column": 4,
+      "line": 7,
+    },
+    "start": Position {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "program": Node {
+    "body": Array [
+      Node {
+        "declarations": Array [
+          Node {
+            "end": 82,
+            "id": Node {
+              "end": 16,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 15,
+                  "line": 2,
+                },
+                "identifierName": "f",
+                "start": Position {
+                  "column": 14,
+                  "line": 2,
+                },
+              },
+              "name": "f",
+              "start": 15,
+              "type": "Identifier",
+            },
+            "init": Node {
+              "body": Node {
+                "body": Array [
+                  Node {
+                    "argument": Node {
+                      "body": Node {
+                        "body": Array [],
+                        "directives": Array [],
+                        "end": 72,
+                        "loc": SourceLocation {
+                          "end": Position {
+                            "column": 11,
+                            "line": 5,
+                          },
+                          "start": Position {
+                            "column": 27,
+                            "line": 3,
+                          },
+                        },
+                        "start": 58,
+                        "type": "BlockStatement",
+                      },
+                      "effects": Array [],
+                      "end": 72,
+                      "loc": SourceLocation {
+                        "end": Position {
+                          "column": 11,
+                          "line": 5,
+                        },
+                        "start": Position {
+                          "column": 17,
+                          "line": 3,
+                        },
+                      },
+                      "start": 48,
+                      "type": "EffectHandler",
+                    },
+                    "end": 72,
+                    "loc": SourceLocation {
+                      "end": Position {
+                        "column": 11,
+                        "line": 5,
+                      },
+                      "start": Position {
+                        "column": 10,
+                        "line": 3,
+                      },
+                    },
+                    "start": 41,
+                    "type": "ReturnStatement",
+                  },
+                ],
+                "directives": Array [],
+                "end": 82,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 9,
+                    "line": 6,
+                  },
+                  "start": Position {
+                    "column": 28,
+                    "line": 2,
+                  },
+                },
+                "start": 29,
+                "type": "BlockStatement",
+              },
+              "effects": Array [],
+              "end": 82,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 9,
+                  "line": 6,
+                },
+                "start": Position {
+                  "column": 18,
+                  "line": 2,
+                },
+              },
+              "start": 19,
+              "type": "EffectHandler",
+            },
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 9,
+                "line": 6,
+              },
+              "start": Position {
+                "column": 14,
+                "line": 2,
+              },
+            },
+            "start": 15,
+            "type": "VariableDeclarator",
+          },
+        ],
+        "end": 83,
+        "kind": "const",
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 10,
+            "line": 6,
+          },
+          "start": Position {
+            "column": 8,
+            "line": 2,
+          },
+        },
+        "start": 9,
+        "type": "VariableDeclaration",
+      },
+    ],
+    "directives": Array [],
+    "end": 88,
+    "interpreter": null,
+    "loc": SourceLocation {
+      "end": Position {
+        "column": 4,
+        "line": 7,
+      },
+      "start": Position {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "sourceType": "module",
+    "start": 0,
+    "type": "Program",
+  },
+  "start": 0,
+  "type": "File",
+}
+`;
+
 exports[`perform keyword Should parse 1`] = `
 Node {
   "comments": Array [],
@@ -102,6 +1210,7 @@ Node {
           "start": 22,
           "type": "BlockStatement",
         },
+        "effect": false,
         "end": 57,
         "generator": false,
         "id": Node {
@@ -143,1047 +1252,6 @@ Node {
       "end": Position {
         "column": 4,
         "line": 5,
-      },
-      "start": Position {
-        "column": 0,
-        "line": 1,
-      },
-    },
-    "sourceType": "module",
-    "start": 0,
-    "type": "Program",
-  },
-  "start": 0,
-  "type": "File",
-}
-`;
-
-exports[`resume keyword Should parse 1`] = `
-Node {
-  "comments": Array [],
-  "end": 88,
-  "errors": Array [],
-  "loc": SourceLocation {
-    "end": Position {
-      "column": 4,
-      "line": 6,
-    },
-    "start": Position {
-      "column": 0,
-      "line": 1,
-    },
-  },
-  "program": Node {
-    "body": Array [
-      Node {
-        "async": false,
-        "body": Node {
-          "body": Array [
-            Node {
-              "end": 54,
-              "expression": Node {
-                "argument": Node {
-                  "end": 52,
-                  "extra": Object {
-                    "parenStart": 42,
-                    "parenthesized": true,
-                  },
-                  "loc": SourceLocation {
-                    "end": Position {
-                      "column": 25,
-                      "line": 3,
-                    },
-                    "start": Position {
-                      "column": 16,
-                      "line": 3,
-                    },
-                  },
-                  "properties": Array [
-                    Node {
-                      "computed": false,
-                      "end": 51,
-                      "key": Node {
-                        "end": 45,
-                        "loc": SourceLocation {
-                          "end": Position {
-                            "column": 18,
-                            "line": 3,
-                          },
-                          "identifierName": "a",
-                          "start": Position {
-                            "column": 17,
-                            "line": 3,
-                          },
-                        },
-                        "name": "a",
-                        "start": 44,
-                        "type": "Identifier",
-                      },
-                      "loc": SourceLocation {
-                        "end": Position {
-                          "column": 24,
-                          "line": 3,
-                        },
-                        "start": Position {
-                          "column": 17,
-                          "line": 3,
-                        },
-                      },
-                      "method": false,
-                      "shorthand": false,
-                      "start": 44,
-                      "type": "ObjectProperty",
-                      "value": Node {
-                        "end": 51,
-                        "extra": Object {
-                          "raw": "'a'",
-                          "rawValue": "a",
-                        },
-                        "loc": SourceLocation {
-                          "end": Position {
-                            "column": 24,
-                            "line": 3,
-                          },
-                          "start": Position {
-                            "column": 21,
-                            "line": 3,
-                          },
-                        },
-                        "start": 48,
-                        "type": "StringLiteral",
-                        "value": "a",
-                      },
-                    },
-                  ],
-                  "start": 43,
-                  "type": "ObjectExpression",
-                },
-                "end": 53,
-                "loc": SourceLocation {
-                  "end": Position {
-                    "column": 26,
-                    "line": 3,
-                  },
-                  "start": Position {
-                    "column": 8,
-                    "line": 3,
-                  },
-                },
-                "operator": "recall",
-                "prefix": true,
-                "start": 35,
-                "type": "UnaryExpression",
-              },
-              "loc": SourceLocation {
-                "end": Position {
-                  "column": 27,
-                  "line": 3,
-                },
-                "start": Position {
-                  "column": 8,
-                  "line": 3,
-                },
-              },
-              "start": 35,
-              "type": "ExpressionStatement",
-            },
-            Node {
-              "end": 75,
-              "expression": Node {
-                "argument": Node {
-                  "end": 74,
-                  "loc": SourceLocation {
-                    "end": Position {
-                      "column": 19,
-                      "line": 4,
-                    },
-                    "start": Position {
-                      "column": 15,
-                      "line": 4,
-                    },
-                  },
-                  "start": 70,
-                  "type": "BooleanLiteral",
-                  "value": true,
-                },
-                "end": 74,
-                "loc": SourceLocation {
-                  "end": Position {
-                    "column": 19,
-                    "line": 4,
-                  },
-                  "start": Position {
-                    "column": 8,
-                    "line": 4,
-                  },
-                },
-                "operator": "recall",
-                "prefix": true,
-                "start": 63,
-                "type": "UnaryExpression",
-              },
-              "loc": SourceLocation {
-                "end": Position {
-                  "column": 20,
-                  "line": 4,
-                },
-                "start": Position {
-                  "column": 8,
-                  "line": 4,
-                },
-              },
-              "start": 63,
-              "type": "ExpressionStatement",
-            },
-          ],
-          "directives": Array [],
-          "end": 83,
-          "loc": SourceLocation {
-            "end": Position {
-              "column": 7,
-              "line": 5,
-            },
-            "start": Position {
-              "column": 24,
-              "line": 2,
-            },
-          },
-          "start": 25,
-          "type": "BlockStatement",
-        },
-        "end": 83,
-        "generator": false,
-        "id": Node {
-          "end": 23,
-          "loc": SourceLocation {
-            "end": Position {
-              "column": 22,
-              "line": 2,
-            },
-            "identifierName": "handler",
-            "start": Position {
-              "column": 15,
-              "line": 2,
-            },
-          },
-          "name": "handler",
-          "start": 16,
-          "type": "Identifier",
-        },
-        "loc": SourceLocation {
-          "end": Position {
-            "column": 7,
-            "line": 5,
-          },
-          "start": Position {
-            "column": 6,
-            "line": 2,
-          },
-        },
-        "params": Array [],
-        "start": 7,
-        "type": "FunctionDeclaration",
-      },
-    ],
-    "directives": Array [],
-    "end": 88,
-    "interpreter": null,
-    "loc": SourceLocation {
-      "end": Position {
-        "column": 4,
-        "line": 6,
-      },
-      "start": Position {
-        "column": 0,
-        "line": 1,
-      },
-    },
-    "sourceType": "module",
-    "start": 0,
-    "type": "Program",
-  },
-  "start": 0,
-  "type": "File",
-}
-`;
-
-exports[`try/handle keyword Should parse a default handler case 1`] = `
-Node {
-  "comments": Array [],
-  "end": 121,
-  "errors": Array [],
-  "loc": SourceLocation {
-    "end": Position {
-      "column": 5,
-      "line": 10,
-    },
-    "start": Position {
-      "column": 0,
-      "line": 1,
-    },
-  },
-  "program": Node {
-    "body": Array [
-      Node {
-        "block": Node {
-          "body": Array [],
-          "directives": Array [],
-          "end": 16,
-          "loc": SourceLocation {
-            "end": Position {
-              "column": 5,
-              "line": 4,
-            },
-            "start": Position {
-              "column": 7,
-              "line": 2,
-            },
-          },
-          "start": 8,
-          "type": "BlockStatement",
-        },
-        "end": 121,
-        "finalizer": null,
-        "handler": Node {
-          "alternate": Node {
-            "end": 0,
-            "handler": Node {
-              "alternate": Node {
-                "end": 0,
-                "handler": Node {
-                  "alternate": null,
-                  "body": Node {
-                    "body": Array [],
-                    "directives": Array [],
-                    "end": 121,
-                    "loc": SourceLocation {
-                      "end": Position {
-                        "column": 5,
-                        "line": 10,
-                      },
-                      "start": Position {
-                        "column": 29,
-                        "line": 8,
-                      },
-                    },
-                    "start": 113,
-                    "type": "BlockStatement",
-                  },
-                  "defaultMatcher": true,
-                  "effectMatcher": null,
-                  "end": 121,
-                  "loc": SourceLocation {
-                    "end": Position {
-                      "column": 5,
-                      "line": 10,
-                    },
-                    "start": Position {
-                      "column": 13,
-                      "line": 8,
-                    },
-                  },
-                  "param": Node {
-                    "end": 112,
-                    "loc": SourceLocation {
-                      "end": Position {
-                        "column": 28,
-                        "line": 8,
-                      },
-                      "identifierName": "e",
-                      "start": Position {
-                        "column": 27,
-                        "line": 8,
-                      },
-                    },
-                    "name": "e",
-                    "start": 111,
-                    "type": "Identifier",
-                  },
-                  "start": 97,
-                  "type": "HandleClause",
-                },
-                "loc": SourceLocation {
-                  "end": undefined,
-                  "start": Position {
-                    "column": 6,
-                    "line": 8,
-                  },
-                },
-                "start": 90,
-                "type": "",
-              },
-              "body": Node {
-                "body": Array [],
-                "directives": Array [],
-                "end": 89,
-                "loc": SourceLocation {
-                  "end": Position {
-                    "column": 5,
-                    "line": 8,
-                  },
-                  "start": Position {
-                    "column": 38,
-                    "line": 6,
-                  },
-                },
-                "start": 81,
-                "type": "BlockStatement",
-              },
-              "defaultMatcher": false,
-              "effectMatcher": Node {
-                "arguments": Array [
-                  Node {
-                    "end": 71,
-                    "extra": Object {
-                      "raw": "'effect'",
-                      "rawValue": "effect",
-                    },
-                    "loc": SourceLocation {
-                      "end": Position {
-                        "column": 28,
-                        "line": 6,
-                      },
-                      "start": Position {
-                        "column": 20,
-                        "line": 6,
-                      },
-                    },
-                    "start": 63,
-                    "type": "StringLiteral",
-                    "value": "effect",
-                  },
-                ],
-                "callee": Node {
-                  "end": 62,
-                  "loc": SourceLocation {
-                    "end": Position {
-                      "column": 19,
-                      "line": 6,
-                    },
-                    "identifierName": "Symbol",
-                    "start": Position {
-                      "column": 13,
-                      "line": 6,
-                    },
-                  },
-                  "name": "Symbol",
-                  "start": 56,
-                  "type": "Identifier",
-                },
-                "end": 72,
-                "loc": SourceLocation {
-                  "end": Position {
-                    "column": 29,
-                    "line": 6,
-                  },
-                  "start": Position {
-                    "column": 13,
-                    "line": 6,
-                  },
-                },
-                "start": 56,
-                "type": "CallExpression",
-              },
-              "end": 121,
-              "loc": SourceLocation {
-                "end": Position {
-                  "column": 5,
-                  "line": 10,
-                },
-                "start": Position {
-                  "column": 13,
-                  "line": 6,
-                },
-              },
-              "param": Node {
-                "end": 80,
-                "loc": SourceLocation {
-                  "end": Position {
-                    "column": 37,
-                    "line": 6,
-                  },
-                  "identifierName": "e",
-                  "start": Position {
-                    "column": 36,
-                    "line": 6,
-                  },
-                },
-                "name": "e",
-                "start": 79,
-                "type": "Identifier",
-              },
-              "start": 56,
-              "type": "HandleClause",
-            },
-            "loc": SourceLocation {
-              "end": undefined,
-              "start": Position {
-                "column": 6,
-                "line": 6,
-              },
-            },
-            "start": 49,
-            "type": "",
-          },
-          "body": Node {
-            "body": Array [],
-            "directives": Array [],
-            "end": 48,
-            "loc": SourceLocation {
-              "end": Position {
-                "column": 5,
-                "line": 6,
-              },
-              "start": Position {
-                "column": 29,
-                "line": 4,
-              },
-            },
-            "start": 40,
-            "type": "BlockStatement",
-          },
-          "defaultMatcher": false,
-          "effectMatcher": Node {
-            "end": 30,
-            "loc": SourceLocation {
-              "end": Position {
-                "column": 19,
-                "line": 4,
-              },
-              "identifierName": "someVar",
-              "start": Position {
-                "column": 12,
-                "line": 4,
-              },
-            },
-            "name": "someVar",
-            "start": 23,
-            "type": "Identifier",
-          },
-          "end": 121,
-          "loc": SourceLocation {
-            "end": Position {
-              "column": 5,
-              "line": 10,
-            },
-            "start": Position {
-              "column": 12,
-              "line": 4,
-            },
-          },
-          "param": Node {
-            "end": 38,
-            "loc": SourceLocation {
-              "end": Position {
-                "column": 27,
-                "line": 4,
-              },
-              "identifierName": "e",
-              "start": Position {
-                "column": 26,
-                "line": 4,
-              },
-            },
-            "name": "e",
-            "start": 37,
-            "type": "Identifier",
-          },
-          "start": 23,
-          "type": "HandleClause",
-        },
-        "loc": SourceLocation {
-          "end": Position {
-            "column": 5,
-            "line": 10,
-          },
-          "start": Position {
-            "column": 4,
-            "line": 2,
-          },
-        },
-        "start": 5,
-        "type": "TryStatement",
-      },
-    ],
-    "directives": Array [],
-    "end": 121,
-    "interpreter": null,
-    "loc": SourceLocation {
-      "end": Position {
-        "column": 5,
-        "line": 10,
-      },
-      "start": Position {
-        "column": 0,
-        "line": 1,
-      },
-    },
-    "sourceType": "module",
-    "start": 0,
-    "type": "Program",
-  },
-  "start": 0,
-  "type": "File",
-}
-`;
-
-exports[`try/handle keyword Should parse alternate handler case  1`] = `
-Node {
-  "comments": Array [],
-  "end": 91,
-  "errors": Array [],
-  "loc": SourceLocation {
-    "end": Position {
-      "column": 5,
-      "line": 8,
-    },
-    "start": Position {
-      "column": 0,
-      "line": 1,
-    },
-  },
-  "program": Node {
-    "body": Array [
-      Node {
-        "block": Node {
-          "body": Array [],
-          "directives": Array [],
-          "end": 16,
-          "loc": SourceLocation {
-            "end": Position {
-              "column": 5,
-              "line": 4,
-            },
-            "start": Position {
-              "column": 7,
-              "line": 2,
-            },
-          },
-          "start": 8,
-          "type": "BlockStatement",
-        },
-        "end": 91,
-        "finalizer": null,
-        "handler": Node {
-          "alternate": Node {
-            "end": 0,
-            "handler": Node {
-              "alternate": null,
-              "body": Node {
-                "body": Array [],
-                "directives": Array [],
-                "end": 91,
-                "loc": SourceLocation {
-                  "end": Position {
-                    "column": 5,
-                    "line": 8,
-                  },
-                  "start": Position {
-                    "column": 36,
-                    "line": 6,
-                  },
-                },
-                "start": 83,
-                "type": "BlockStatement",
-              },
-              "defaultMatcher": false,
-              "effectMatcher": Node {
-                "end": 74,
-                "extra": Object {
-                  "raw": "'anotherEffect'",
-                  "rawValue": "anotherEffect",
-                },
-                "loc": SourceLocation {
-                  "end": Position {
-                    "column": 27,
-                    "line": 6,
-                  },
-                  "start": Position {
-                    "column": 12,
-                    "line": 6,
-                  },
-                },
-                "start": 59,
-                "type": "StringLiteral",
-                "value": "anotherEffect",
-              },
-              "end": 91,
-              "loc": SourceLocation {
-                "end": Position {
-                  "column": 5,
-                  "line": 8,
-                },
-                "start": Position {
-                  "column": 12,
-                  "line": 6,
-                },
-              },
-              "param": Node {
-                "end": 82,
-                "loc": SourceLocation {
-                  "end": Position {
-                    "column": 35,
-                    "line": 6,
-                  },
-                  "identifierName": "e",
-                  "start": Position {
-                    "column": 34,
-                    "line": 6,
-                  },
-                },
-                "name": "e",
-                "start": 81,
-                "type": "Identifier",
-              },
-              "start": 59,
-              "type": "HandleClause",
-            },
-            "loc": SourceLocation {
-              "end": undefined,
-              "start": Position {
-                "column": 5,
-                "line": 6,
-              },
-            },
-            "start": 52,
-            "type": "",
-          },
-          "body": Node {
-            "body": Array [],
-            "directives": Array [],
-            "end": 52,
-            "loc": SourceLocation {
-              "end": Position {
-                "column": 5,
-                "line": 6,
-              },
-              "start": Position {
-                "column": 33,
-                "line": 4,
-              },
-            },
-            "start": 44,
-            "type": "BlockStatement",
-          },
-          "defaultMatcher": false,
-          "effectMatcher": Node {
-            "end": 35,
-            "extra": Object {
-              "raw": "'someEffect'",
-              "rawValue": "someEffect",
-            },
-            "loc": SourceLocation {
-              "end": Position {
-                "column": 24,
-                "line": 4,
-              },
-              "start": Position {
-                "column": 12,
-                "line": 4,
-              },
-            },
-            "start": 23,
-            "type": "StringLiteral",
-            "value": "someEffect",
-          },
-          "end": 91,
-          "loc": SourceLocation {
-            "end": Position {
-              "column": 5,
-              "line": 8,
-            },
-            "start": Position {
-              "column": 12,
-              "line": 4,
-            },
-          },
-          "param": Node {
-            "end": 43,
-            "loc": SourceLocation {
-              "end": Position {
-                "column": 32,
-                "line": 4,
-              },
-              "identifierName": "e",
-              "start": Position {
-                "column": 31,
-                "line": 4,
-              },
-            },
-            "name": "e",
-            "start": 42,
-            "type": "Identifier",
-          },
-          "start": 23,
-          "type": "HandleClause",
-        },
-        "loc": SourceLocation {
-          "end": Position {
-            "column": 5,
-            "line": 8,
-          },
-          "start": Position {
-            "column": 4,
-            "line": 2,
-          },
-        },
-        "start": 5,
-        "type": "TryStatement",
-      },
-    ],
-    "directives": Array [],
-    "end": 91,
-    "interpreter": null,
-    "loc": SourceLocation {
-      "end": Position {
-        "column": 5,
-        "line": 8,
-      },
-      "start": Position {
-        "column": 0,
-        "line": 1,
-      },
-    },
-    "sourceType": "module",
-    "start": 0,
-    "type": "Program",
-  },
-  "start": 0,
-  "type": "File",
-}
-`;
-
-exports[`try/handle keyword Should parse basic handler case 1`] = `
-Node {
-  "comments": Array [],
-  "end": 118,
-  "errors": Array [],
-  "loc": SourceLocation {
-    "end": Position {
-      "column": 4,
-      "line": 9,
-    },
-    "start": Position {
-      "column": 0,
-      "line": 1,
-    },
-  },
-  "program": Node {
-    "body": Array [
-      Node {
-        "async": false,
-        "body": Node {
-          "body": Array [
-            Node {
-              "block": Node {
-                "body": Array [
-                  Node {
-                    "end": 54,
-                    "expression": Node {
-                      "arguments": Array [],
-                      "callee": Node {
-                        "end": 51,
-                        "loc": SourceLocation {
-                          "end": Position {
-                            "column": 14,
-                            "line": 4,
-                          },
-                          "identifierName": "main",
-                          "start": Position {
-                            "column": 10,
-                            "line": 4,
-                          },
-                        },
-                        "name": "main",
-                        "start": 47,
-                        "type": "Identifier",
-                      },
-                      "end": 53,
-                      "loc": SourceLocation {
-                        "end": Position {
-                          "column": 16,
-                          "line": 4,
-                        },
-                        "start": Position {
-                          "column": 10,
-                          "line": 4,
-                        },
-                      },
-                      "start": 47,
-                      "type": "CallExpression",
-                    },
-                    "loc": SourceLocation {
-                      "end": Position {
-                        "column": 17,
-                        "line": 4,
-                      },
-                      "start": Position {
-                        "column": 10,
-                        "line": 4,
-                      },
-                    },
-                    "start": 47,
-                    "type": "ExpressionStatement",
-                  },
-                ],
-                "directives": Array [],
-                "end": 64,
-                "loc": SourceLocation {
-                  "end": Position {
-                    "column": 9,
-                    "line": 5,
-                  },
-                  "start": Position {
-                    "column": 11,
-                    "line": 3,
-                  },
-                },
-                "start": 35,
-                "type": "BlockStatement",
-              },
-              "end": 105,
-              "finalizer": null,
-              "handler": Node {
-                "alternate": null,
-                "body": Node {
-                  "body": Array [],
-                  "directives": Array [],
-                  "end": 105,
-                  "loc": SourceLocation {
-                    "end": Position {
-                      "column": 9,
-                      "line": 7,
-                    },
-                    "start": Position {
-                      "column": 38,
-                      "line": 5,
-                    },
-                  },
-                  "start": 93,
-                  "type": "BlockStatement",
-                },
-                "defaultMatcher": false,
-                "effectMatcher": Node {
-                  "end": 84,
-                  "extra": Object {
-                    "raw": "'someEffect'",
-                    "rawValue": "someEffect",
-                  },
-                  "loc": SourceLocation {
-                    "end": Position {
-                      "column": 29,
-                      "line": 5,
-                    },
-                    "start": Position {
-                      "column": 17,
-                      "line": 5,
-                    },
-                  },
-                  "start": 72,
-                  "type": "StringLiteral",
-                  "value": "someEffect",
-                },
-                "end": 105,
-                "loc": SourceLocation {
-                  "end": Position {
-                    "column": 9,
-                    "line": 7,
-                  },
-                  "start": Position {
-                    "column": 17,
-                    "line": 5,
-                  },
-                },
-                "param": Node {
-                  "end": 92,
-                  "loc": SourceLocation {
-                    "end": Position {
-                      "column": 37,
-                      "line": 5,
-                    },
-                    "identifierName": "e",
-                    "start": Position {
-                      "column": 36,
-                      "line": 5,
-                    },
-                  },
-                  "name": "e",
-                  "start": 91,
-                  "type": "Identifier",
-                },
-                "start": 72,
-                "type": "HandleClause",
-              },
-              "loc": SourceLocation {
-                "end": Position {
-                  "column": 9,
-                  "line": 7,
-                },
-                "start": Position {
-                  "column": 8,
-                  "line": 3,
-                },
-              },
-              "start": 32,
-              "type": "TryStatement",
-            },
-          ],
-          "directives": Array [],
-          "end": 113,
-          "loc": SourceLocation {
-            "end": Position {
-              "column": 7,
-              "line": 8,
-            },
-            "start": Position {
-              "column": 21,
-              "line": 2,
-            },
-          },
-          "start": 22,
-          "type": "BlockStatement",
-        },
-        "end": 113,
-        "generator": false,
-        "id": Node {
-          "end": 20,
-          "loc": SourceLocation {
-            "end": Position {
-              "column": 19,
-              "line": 2,
-            },
-            "identifierName": "main",
-            "start": Position {
-              "column": 15,
-              "line": 2,
-            },
-          },
-          "name": "main",
-          "start": 16,
-          "type": "Identifier",
-        },
-        "loc": SourceLocation {
-          "end": Position {
-            "column": 7,
-            "line": 8,
-          },
-          "start": Position {
-            "column": 6,
-            "line": 2,
-          },
-        },
-        "params": Array [],
-        "start": 7,
-        "type": "FunctionDeclaration",
-      },
-    ],
-    "directives": Array [],
-    "end": 118,
-    "interpreter": null,
-    "loc": SourceLocation {
-      "end": Position {
-        "column": 4,
-        "line": 9,
       },
       "start": Position {
         "column": 0,

--- a/packages/babel-parser/test/perform-keyword.js
+++ b/packages/babel-parser/test/perform-keyword.js
@@ -2,6 +2,40 @@ import { parse } from "../lib";
 
 const getParserWithCode = code => () => parse(code, { sourceType: "module" });
 
+describe("handle keyword", () => {
+  it("Should parse a handle block", () => {
+    const parser = getParserWithCode(`
+      handle (A) {
+        const x = 0;
+      }
+    `);
+
+    expect(parser()).toMatchSnapshot();
+  });
+
+  it("Should parse a handle block as expression", () => {
+    const parser = getParserWithCode(`
+        const f = handle () {
+          return null;
+        };
+    `);
+
+    expect(parser()).toMatchSnapshot();
+  });
+
+  it("Should parse a nested handle block", () => {
+    const parser = getParserWithCode(`
+        const f = handle () {
+          return handle () {
+
+          }
+        };
+    `);
+
+    expect(parser()).toMatchSnapshot();
+  });
+});
+
 describe("perform keyword", () => {
   it("Should parse", () => {
     const parser = getParserWithCode(`
@@ -13,59 +47,45 @@ describe("perform keyword", () => {
   });
 });
 
-describe("try/handle keyword", () => {
-  it("Should parse basic handler case", () => {
+describe("effect / recall keyword", () => {
+  it("Should parse a handle keyword", () => {
     const parser = getParserWithCode(`
-      function main(){
-        try{
-          main();
-        } handle 'someEffect' with (e){
+        const y = effect (x) => {
 
         }
+   `);
+    expect(parser()).toMatchSnapshot();
+  });
+
+  it("Should parse a recall keyword within the scope of an effect", () => {
+    const parser = getParserWithCode(`
+      const z = effect () => {
+        recall "Hello"
       }
     `);
 
     expect(parser()).toMatchSnapshot();
   });
 
-  it("Should parse alternate handler case ", () => {
+  it("Should parse a function statement as an effect", () => {
     const parser = getParserWithCode(`
-    try{
+      effect function A() {
+        recall "Hi";
+      }
 
-    }handle 'someEffect' with (e){
-
-    }handle 'anotherEffect' with (e){
-
-    }`);
-
-    expect(parser()).toMatchSnapshot();
-  });
-
-  it("Should parse a default handler case", () => {
-    const parser = getParserWithCode(`
-    try{
-
-    }handle someVar with (e) {
-
-    } handle Symbol('effect') with (e){
-
-    } handle default with (e){
-
-    }`);
-
-    expect(parser()).toMatchSnapshot();
-  });
-});
-
-describe("resume keyword", () => {
-  it("Should parse", () => {
-    const parser = getParserWithCode(`
-      function handler(){
-        recall ({a : 'a'});
-        recall true;
+      const B = effect function(){
+        recall "Yo";
       }
     `);
 
     expect(parser()).toMatchSnapshot();
+  });
+
+  it("Should not parse a recall keyword outside the scope of an effect", () => {
+    const parser = getParserWithCode(`
+      recall "bad";
+    `);
+
+    expect(parser).toThrowError();
   });
 });


### PR DESCRIPTION
## New grammar specification for Effects:

### handle block

Distancing from the try/catch mental model, effects are now initiated with a handle block:

```
// handle ( <parameter-list> ) <block>

handle (A) {

}
```

A handle-block is treated like an iife, and may return:

```
let f = handle(A) {
  return `look ma no hands!`;
}
```

Handle blocks represent a boundary between the virtual stack and the normal stack. In order to preserve asynchronous handling, the return value of a handle block is a promise:

```
left f = handle(A){
  if( perform A(true) ){
    return "OK"
  }

  throw new Error(":{");
}

f.then(
 (result) => { // result === "OK" }
).catch(
 (error) => { // error.message === ":{" }
)
```

This property allows `await` to be used within a `handle` block without specifying it as `async`. `handle` can be thought of as specifying that the next block of code is both `async` and a `generator`.

Therefore, values may also be `yield`ed within a handle block. When `yield`ing an expression, the current context is paused and the expression is evaluated by the effects runtime. For all values other than generators, iterators and `handle` blocks, `yield` functions as assignment:

```
handle (A) {
  const a = x => x;
  
  const x = yield "hello";
  const b = yield a; 

   //x === "hello"
   // b === a
}
```

However, generators, iterators and handle blocks have special meaning in this context:

```
function* X(){
  let x = 0;
  while(++x < 10) yield x;
  return x;
}

handle (A) {
  const x = yield X();

  const y = yield handle (B){
      return "Result"
  };
  // x === 10;
  // y === "Result"
}
```

From the above example, a generator yielded to the runtime will be evaluated as if it were a regular function.

Finally, nested `handle` blocks are composable:

```
let f = handle (A) {
  let g = yield handle (B) {

  }
};

let x = handle (A, B) {

}

// g === x;
```

A few key takeaways here are:

* a handle block is like a normal block of code that get's executed at the call-site
* the result of a handle block must be extracted with a promise.
* the body of a handle block is async and a generator, both `yield` and `await` are valid.

See below on the impact and meaning of these changes

### perform

The mechanics of perform remain similar, you `perform` effects from within a `handle` block. The key difference is effects are now functions, not clunky stringly typed pojos:

```
handle () {
  let result = perform SomeEffect("Add whatever you like");
  let otherResult = perform OtherEffect(1,2,3,4,5);
}
```

Effects still happen in guaranteed order, in the above code sample `otherResult` will always execute after `result` no matter the asynchronous nature of `SomeEffect` and `OtherEffect`.

### effect

The `effect` qualifier is new, it replaces the `handle` block of the previous effect system. All of the following are valid ways to define effects:
```
// <variableDeclarator> = effect (<parameterList>) => <block>
const x = effect () => {

};

// <variableDeclarator> = effect function (<parameterList>) <block>
const y = effect function(){

};

// effect function <identifier>(<parameterList>) <block>
effect function z(){

}
```

Effect function blocks are asynchronous in nature, so `await` may be used. 

The return type of an effect is always a function that returns a generator when invoked, such that

```
type DelimitedContinuation = <T>(x: T) => void
type EffectReturnType = <T>(dc: DelimitedContinuation<T>) => void

const A = effect <T>A(x: T) : EffectReturnType<T> => {}
```

### Recall

The recall keyword remains the same:

```
const X = effect () => setTimeout(
  () => recall `I waited a bit before responding`,
  500
);
```


## * Short essay on the new `handle` syntax

One of the biggest problems of the old syntax was the liberty it gave with the use of the `perform` keyword. Under the old model, any function could perform. This resulted in a lot of bending over backwards at the transform level, and some troubling inconsistencies with the proposal. 

At the heart of it, the effects system is implemented with generators. Any function that performs must be converted into a generator. If generators had been implemented [in a different way](https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/Legacy_generator_function_statement), this wouldn't have been a problem. However, because functions must go through this transformation, the only way to safely transform would be to create a callgraph over all valid code paths and convert to generators all the way up.

This isn't what the transform plugin did because it would create too big of an impact and cause code to drift too far from it's original intent. So it made a good faith effort and hoped for the best. The worst of it was that even this good faith effort changed code too much. This also lead to the `Boundary` specification, which killed development on `effectsjs` because it was a half measured approach to some unsolvable problems. There is still room for `Boundary`, but it plays a much smaller role.

The drawback of course is that though nested `handle` blocks still behave as expected, they don't interop _quite_ as nicely. This in my opinion is OK. I found from experimentation that nesting too many `try/handle`s (now just `handle`s) felt something akin to an anti-pattern, and that it was often more clear to introduce effects from the top.

Because `handle` blocks are asynchronous in nature, care must be taken when composing them. Let's compare two very similar examples

```
let f = handle (A) {
  let g = handle (B) {
    return perform EffectB();
  }

  perform EffectA();
};

let x = handle (A) {
  let y = yield handle(B){
    return perform EffectB();
  }

  perform EffectA();
}
```

`f` and `x` function **differently**! Previously, this ambiguity was resolved by the `'use effects'` directive to indicate the beginning of the virtual stack. This kind of asymmetry was ugly, hard to account for and contributed to the same kind of problems as above.

The `yield` keyword solves this ambiguity: an isolated or top-level handle block indicates the beginning of a virtual stack. `yield`ing a handle block from within the context of another handle block indicates a _link_ in the virtual stack. 

Thus, in the above example `f` and `g` are executing in **different** virtual stacks. Therefore:
1. They are not composed: `g` _may not_ perform `EffectA`
1. The execution order _is not_ guaranteed : `EffectB` may finish before`EffectA`
1. `g` is a `Promise`, whereas `y` is the result of the performed `EffectB`